### PR TITLE
Implement unread message detection

### DIFF
--- a/background.js
+++ b/background.js
@@ -110,7 +110,12 @@ function startMessageChecker() {
     chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
       if (tabs[0] && (tabs[0].url.includes('facebook.com/messages') || tabs[0].url.includes('messenger.com/marketplace'))) {
         // Send message to content script to check for new messages
-        chrome.tabs.sendMessage(tabs[0].id, { action: 'checkForNewMessages' });
+        chrome.tabs.sendMessage(tabs[0].id, { action: 'checkForNewMessages' }, (res) => {
+          if (chrome.runtime.lastError) return;
+          if (res && Array.isArray(res.unread) && res.unread.length) {
+            debugLog('Unread messages:', res.unread);
+          }
+        });
       }
     });
   }, 30000); // 30 seconds

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -238,7 +238,10 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
           }
           if (response.chats) {
-            response.chats.forEach((c, i) => debugLog(`#${i + 1}: ${c.title} (ID: ${c.id})`));
+            response.chats.forEach((c, i) => {
+              const flag = c.unread ? 'UNREAD' : 'read';
+              debugLog(`#${i + 1}: ${c.title} (ID: ${c.id}) - ${flag}`);
+            });
           } else if (response.messages) {
             response.messages.forEach((m, i) => debugLog(`#${i + 1} [${m.sender}]: ${m.text}`));
           } else if (response.title) {


### PR DESCRIPTION
## Summary
- add DOM scan for chats marked as unread
- support `checkForNewMessages` request in the content script handler
- log unread messages from the background message checker
- display unread flag when scanning top chats

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68618aaf81b8832fb1938913ec4cd4dd