### PR TITLE
Handle oldest unread chat sequentially

### DIFF
--- a/background.js
+++ b/background.js
@@ -105,15 +105,14 @@ function loadState() {
 let messageCheckInterval;
 
 function startMessageChecker() {
-  // Check for new messages every 30 seconds
+  // Process unread chats every 30 seconds
   messageCheckInterval = setInterval(() => {
     chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
       if (tabs[0] && (tabs[0].url.includes('facebook.com/messages') || tabs[0].url.includes('messenger.com/marketplace'))) {
-        // Send message to content script to check for new messages
-        chrome.tabs.sendMessage(tabs[0].id, { action: 'checkForNewMessages' }, (res) => {
+        chrome.tabs.sendMessage(tabs[0].id, { action: 'processOldestUnread' }, (res) => {
           if (chrome.runtime.lastError) return;
-          if (res && Array.isArray(res.unread) && res.unread.length) {
-            debugLog('Unread messages:', res.unread);
+          if (res && res.processed) {
+            debugLog('Processed unread chat:', res.chatTitle);
           }
         });
       }

--- a/content.js
+++ b/content.js
@@ -33,6 +33,7 @@
     START_BOT:         'startBot',
     STOP_BOT:          'stopBot',
     CHECK_NEW:         'checkForNewMessages',
+    PROCESS_UNREAD:    'processOldestUnread',
     LOG:               'log'
   };
 
@@ -92,6 +93,7 @@ const UNREAD_DOT_SELECTOR =
 
   // Internal state ------------------------------------------------------------
   let isCycling = false;
+  let isProcessingUnread = false;
 
   // ────────────────────────────────────────────────────────────────────────────
   // Overlay manager (UX feedback while bot runs)
@@ -496,10 +498,59 @@ const UNREAD_DOT_SELECTOR =
       isCycling = false;
       Overlay.update('Completado');
       setTimeout(() => Overlay.hide(), 1000);
-  log('Detailed scan completed', results);
-  return results;
-}
-};
+      log('Detailed scan completed', results);
+      return results;
+    },
+
+    async processOldestUnreadChat(msgLimit) {
+      if (isProcessingUnread) return { status: 'busy' };
+      isProcessingUnread = true;
+
+      try {
+        log('Scanning top chats', { step: 'Scanning chats...' });
+        const chats = await this.scanTopChats(20);
+        log('Chats scanned', { step: 'Chats scanned', chatList: chats });
+        const unread = chats.filter(c => c.unread);
+        if (!unread.length) {
+          log('No unread chats found', { step: 'No unread chats found', state: 'success' });
+          return { processed: false };
+        }
+
+        const target = unread[unread.length - 1];
+        log('Opening unread chat', { step: 'Opening chat', chatTitle: target.title });
+        await this.openChatById(target.id);
+
+        log('Waiting for full load', { step: 'Waiting 30s in chat', chatTitle: target.title });
+        await delay(30000);
+
+        log('Capturing messages', { step: 'Capturing messages', chatTitle: target.title });
+
+        const chatTitle = Messenger.extractChatTitle();
+        const messages  = await Messenger.extractLastMessages(msgLimit);
+        const [clientName = chatTitle, listing = chatTitle] = chatTitle
+          .split('·')
+          .map(s => s.trim());
+
+        log('Sending data to API', { step: 'Sending to API', chatTitle, clientName });
+        const response = await ApiClient.sendChat({
+          chatId: target.id,
+          clientName,
+          listing,
+          chatName: chatTitle,
+          messages
+        });
+
+        log('API response received', { step: 'API response', reply: response.reply, chatTitle, state: 'success' });
+
+        return { processed: true, chatTitle, response };
+      } catch (err) {
+        log('Error processing unread chat', { step: 'Error', state: 'error', message: err.message });
+        return { processed: false, error: err.message };
+      } finally {
+        isProcessingUnread = false;
+      }
+    }
+  };
 
   // Detect chats marked as unread in the Marketplace interface
   function checkForNewMessages() {
@@ -561,6 +612,13 @@ const UNREAD_DOT_SELECTOR =
           const msgLimit = await Storage.getNumber('scanLimit', CONFIG.DEFAULT_MSG_LIMIT);
           const data = await ChatScanner.collectChatsData(CONFIG.DEFAULT_CHAT_LIMIT, msgLimit, CONFIG.DEFAULT_DELAY_MS);
           sendResponse({ chatsData: data });
+          break;
+        }
+
+        case MSG.PROCESS_UNREAD: {
+          const msgLimit = await Storage.getNumber('scanLimit', CONFIG.DEFAULT_MSG_LIMIT);
+          const res = await ChatScanner.processOldestUnreadChat(msgLimit);
+          sendResponse(res);
           break;
         }
 

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -26,6 +26,36 @@
       <p>Messages processed: <span id="messagesProcessed">0</span></p>
     </div>
 
+    <div class="section">
+      <h2>Current step:</h2>
+      <div id="currentStep" class="state waiting">Idle</div>
+    </div>
+
+    <div class="section">
+      <h2>Extracting title:</h2>
+      <div id="chatTitle">-</div>
+    </div>
+
+    <div class="section">
+      <h2>Client name:</h2>
+      <div id="clientName">-</div>
+    </div>
+
+    <div class="section">
+      <h2>Chat list:</h2>
+      <ul id="chatList" class="chat-list"></ul>
+    </div>
+
+    <div class="section">
+      <h2>API call status:</h2>
+      <div id="apiStatus">-</div>
+    </div>
+
+    <div class="section">
+      <h2>Response to be sent in chat:</h2>
+      <pre id="apiResponse">-</pre>
+    </div>
+
     <div class="debug-section">
       <h3>Debug Tools</h3>
       <div style="margin-bottom:10px;">

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -8,6 +8,9 @@ function addLogEntry(entry) {
   div.className = 'log-entry';
   div.textContent = entry;
   logList.prepend(div);
+  while (logList.children.length > 10) {
+    logList.removeChild(logList.lastChild);
+  }
 }
 
 function debugLog(message, data) {
@@ -23,6 +26,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const statusText        = document.getElementById('statusText');
   const lastChecked       = document.getElementById('lastChecked');
   const messagesProcessed = document.getElementById('messagesProcessed');
+  const stepEl            = document.getElementById('currentStep');
+  const titleEl           = document.getElementById('chatTitle');
+  const clientEl          = document.getElementById('clientName');
+  const chatListEl        = document.getElementById('chatList');
+  const apiStatusEl       = document.getElementById('apiStatus');
+  const apiRespEl         = document.getElementById('apiResponse');
   const scanLimitInput    = document.getElementById('scanLimitInput');
   const saveScanLimitBtn  = document.getElementById('saveScanLimitBtn');
 
@@ -110,6 +119,34 @@ document.addEventListener('DOMContentLoaded', () => {
         messagesProcessed.textContent = messageCount;
         chrome.storage.local.set({ messageCount });
         debugLog(`Responded to message in "${request.chatTitle || 'Unknown'}"`);
+      }
+    } else if (request.action === 'logToPopup') {
+      if (request.message) debugLog(request.message, request.data);
+      const data = request.data || {};
+      if (data.step && stepEl) {
+        stepEl.textContent = data.step;
+        stepEl.className = `state ${data.state || 'waiting'}`;
+      }
+      if (data.chatTitle && titleEl) {
+        titleEl.textContent = data.chatTitle;
+      }
+      if (data.clientName && clientEl) {
+        clientEl.textContent = data.clientName;
+      }
+      if (Array.isArray(data.chatList) && chatListEl) {
+        chatListEl.innerHTML = '';
+        data.chatList.forEach(c => {
+          const li = document.createElement('li');
+          li.textContent = c.title;
+          if (c.unread) li.classList.add('unread');
+          chatListEl.appendChild(li);
+        });
+      }
+      if (data.apiStatus && apiStatusEl) {
+        apiStatusEl.textContent = data.apiStatus;
+      }
+      if (data.reply && apiRespEl) {
+        apiRespEl.textContent = data.reply;
       }
     }
   });

--- a/popup/styles.css
+++ b/popup/styles.css
@@ -1,5 +1,6 @@
 body {
-  width: 300px;
+  width: 420px;
+  min-height: 650px;
   padding: 15px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
   color: #1c1e21;
@@ -103,6 +104,57 @@ h1 {
 
 .info-section p:last-child {
   margin-bottom: 0;
+}
+
+.section {
+  padding: 15px;
+  border-bottom: 1px solid #dddfe2;
+  font-size: 13px;
+}
+
+.section h2 {
+  margin: 0 0 6px 0;
+  font-size: 14px;
+  color: #333;
+}
+
+.chat-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.chat-list li {
+  padding: 2px 0;
+}
+
+.chat-list li.unread {
+  font-weight: bold;
+}
+
+.state {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.state::before {
+  content: '🟡';
+}
+
+.state.success::before {
+  content: '✅';
+  color: #42b72a;
+}
+
+.state.error::before {
+  content: '❌';
+  color: #dc3545;
+}
+
+.state.waiting::before {
+  content: '⏳';
+  color: #ffc107;
 }
 
 .activity-log {


### PR DESCRIPTION
## Summary
- poll Messenger every 30 seconds and process unread chats
- pick the oldest unread chat from the top 20 results
- wait 30 seconds in the chat before extracting messages
- show sequential bot status in an expanded popup

## Testing
- `node --check background.js`
- `node --check content.js`
- `node --check popup/popup.js`


------
https://chatgpt.com/codex/tasks/task_e_68619511d400832fbe09a5480a45eafd