### PR TITLE
Refactor image sending and cleanup popup

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -116,16 +116,6 @@
     <div class="desc">Automate your Facebook Marketplace replies.<br>Start or stop the bot below.</div>
     <button id="startBotButton" class="main-button">▶ Start Bot</button>
     <button id="stopBotButton" class="main-button">■ Stop Bot</button>
-    <div class="image-test">
-      <input id="imageUrlInput" type="text" placeholder="Image URL" />
-      <select id="imageMethodSelect">
-        <option value="auto">Auto (recommended)</option>
-        <option value="upload">File upload</option>
-        <option value="clipboard">Clipboard paste</option>
-        <option value="dragDrop">Drag &amp; Drop</option>
-      </select>
-      <button id="sendImageButton" class="main-button">Send Test Image</button>
-    </div>
     <div id="status" class="status"></div>
     <div class="footer">
       <span>Need help? <a href="https://github.com/JhonCalle/Facebook-MarketplaceBot-Extension" target="_blank">Docs</a></span>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -2,9 +2,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const startBtn = document.getElementById('startBotButton');
   const stopBtn = document.getElementById('stopBotButton');
   const statusEl = document.getElementById('status');
-  const sendImageBtn = document.getElementById('sendImageButton');
-  const imageUrlInput = document.getElementById('imageUrlInput');
-  const imageMethodSelect = document.getElementById('imageMethodSelect');
 
   function setStatus(msg, isError = false) {
     statusEl.textContent = msg || '';
@@ -70,39 +67,6 @@ document.addEventListener('DOMContentLoaded', () => {
         setStatus('Bot stopped.');
         setTimeout(() => window.close(), 900);
       });
-    });
-  });
-
-  sendImageBtn?.addEventListener('click', async () => {
-    const url = imageUrlInput.value.trim();
-    const method = imageMethodSelect.value;
-    // Accept any http(s) URL for testing
-    const valid = /^https?:\/\/.+/i.test(url);
-    if (!valid) {
-      setStatus('Enter a valid image URL.', true);
-      return;
-    }
-    sendImageBtn.disabled = true;
-    setStatus('Sending image...');
-    const ready = await ensureContentScript();
-    if (!ready) {
-      setStatus('Not a supported page. Open Facebook Messenger.', true);
-      sendImageBtn.disabled = false;
-      return;
-    }
-    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
-      chrome.tabs.sendMessage(
-        tabs[0].id,
-        { action: 'sendTestImage', url, method },
-        res => {
-          sendImageBtn.disabled = false;
-          if (chrome.runtime.lastError || !res?.sent) {
-            setStatus('Failed to send image.', true);
-          } else {
-            setStatus('Image sent!');
-          }
-        }
-      );
     });
   });
 


### PR DESCRIPTION
## Summary
- refactor ImageSender to only use the native file input method
- add helper to detect image replies and send them as images
- use new helper when sending API responses
- simplify popup UI and script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687473fdcd00832f8c1d208611ccb588