### PR TITLE
fix: extend API timeout and improve script reliability

### DIFF
--- a/content.js
+++ b/content.js
@@ -209,7 +209,15 @@ const SYSTEM_FILTERS = [
   // Utilities
   // ────────────────────────────────────────────────────────────────────────────
   function log(message, data) {
-    chrome.runtime.sendMessage({ action: MSG.LOG, message, data });
+    // Echo to the DevTools console for easier debugging
+    console.log(`[Marketplace Bot] ${message}`, data || '');
+
+    // Forward to the background/popup listeners as before
+    try {
+      chrome.runtime.sendMessage({ action: MSG.LOG, message, data });
+    } catch (err) {
+      console.warn('[Marketplace Bot] log forwarding failed', err);
+    }
   }
 
   // ---------------------------------------------------------------
@@ -497,8 +505,8 @@ async extractLastMessages(limit = 20) {
     const webhookUrl = await Storage.getString('webhookUrl', CONFIG.DEFAULT_WEBHOOK_URL);
     this.abortController = new AbortController();
 
-    // ⬆️ Increased from 120000 (2 min) to 180000 (3 min)
-    const TIMEOUT_MS = 180000;
+    // Allow slow APIs up to three minutes to respond
+    const TIMEOUT_MS = 3 * 60 * 1000; // 180000 ms
     let timeoutId;
 
     try {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -47,7 +47,12 @@ document.addEventListener('DOMContentLoaded', () => {
       if (pong?.status === 'active') return true;
     } catch {}
     try {
-      await chrome.scripting.executeScript({ target: { tabId: tabs[0].id }, files: ['content.js'] });
+      // Manually inject all required assets when the content script isn't present
+      await chrome.scripting.insertCSS({ target: { tabId: tabs[0].id }, files: ['overlay.css'] });
+      await chrome.scripting.executeScript({
+        target: { tabId: tabs[0].id },
+        files: ['Utilities.js', 'content.js']
+      });
     } catch {}
     await new Promise(res => setTimeout(res, 300));
     try {


### PR DESCRIPTION
## Summary
- allow up to three minutes for API responses before timing out
- inject Utilities, content script, and CSS when starting on unsupported pages
- log bot actions directly to the DevTools console for easier debugging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68978097d5b8832fb1a8d8b7fa945ea6